### PR TITLE
필터단 예외 발생 시 예외 응답

### DIFF
--- a/src/main/java/com/example/backoffice/global/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/backoffice/global/security/AuthenticationFilter.java
@@ -57,7 +57,15 @@ public class AuthenticationFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 response.setContentType("application/json; charset=UTF-8");
                 response.getWriter().write(objectMapper.writeValueAsString(commonResponseDTO));
+                return;
             }
+        }else {
+            // 인증정보가 존재하지 않을때
+            CommonResponseDTO commonResponseDTO = new CommonResponseDTO("토큰이 유효하지 않습니다.", HttpStatus.FORBIDDEN.value());
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json; charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(commonResponseDTO));
+            return;
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/backoffice/global/security/JwtUtil.java
+++ b/src/main/java/com/example/backoffice/global/security/JwtUtil.java
@@ -74,11 +74,7 @@ public class JwtUtil {
 
     // 토큰에서 유저 정보를 뽑아오기. 유저정보는 claims에 들어있으므로 claim를 반환
     public Claims getUserInfoFromToken(String token) {
-        try {
             return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
-        } catch (NullPointerException e){
-            throw new NonUserExsistException(NON_USER_EXSIST);
-        }
     }
 
     // jwt 토큰을 만드는 메서드.

--- a/src/main/java/com/example/backoffice/global/security/JwtUtil.java
+++ b/src/main/java/com/example/backoffice/global/security/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.example.backoffice.global.security;
 
+import com.example.backoffice.domain.user.exception.NonUserExsistException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -14,12 +15,15 @@ import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 
+import static com.example.backoffice.domain.user.exception.UserErrorCode.NON_USER_EXSIST;
+
 @Slf4j
 @Component
 public class JwtUtil {
 
     // Header KEY 값
     public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_AUTHORIZATION_HEADER = "Refresh_Auth";
 
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
@@ -70,7 +74,11 @@ public class JwtUtil {
 
     // 토큰에서 유저 정보를 뽑아오기. 유저정보는 claims에 들어있으므로 claim를 반환
     public Claims getUserInfoFromToken(String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (NullPointerException e){
+            throw new NonUserExsistException(NON_USER_EXSIST);
+        }
     }
 
     // jwt 토큰을 만드는 메서드.


### PR DESCRIPTION
필터단 예외 발생 시 예외 응답
기존에는 필터단에서 예외 발생시 컨트롤러까지 예외가 넘어갔었습니다.
이제는 필터단에서 인증이 유효하지 않을 경우 필터단에서 예외가 터지고, 예외를 클라이언트에 응답합니다.