### PR TITLE
필터단 예외 처리 & 오타수정

### DIFF
--- a/src/main/java/com/example/backoffice/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/backoffice/domain/post/repository/PostRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    List<Post> findAllByOrOrderByCreatedAtDesc();
+    List<Post> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/example/backoffice/domain/post/service/PostService.java
+++ b/src/main/java/com/example/backoffice/domain/post/service/PostService.java
@@ -59,7 +59,7 @@ public class PostService {
     }
 
     public List<GetAllPostResponseDto> getPostList(User user) {
-        List<Post> postList = postRepository.findAllByOrOrderByCreatedAtDesc();
+        List<Post> postList = postRepository.findAllByOrderByCreatedAtDesc();
         return postList.stream()
             .map(post -> GetAllPostResponseDto.of(post, getPostLiked(user, post)))
             .collect(Collectors.toList());

--- a/src/main/java/com/example/backoffice/global/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/backoffice/global/security/AuthenticationFilter.java
@@ -57,7 +57,15 @@ public class AuthenticationFilter extends OncePerRequestFilter {
                 response.setStatus(HttpServletResponse.SC_FORBIDDEN);
                 response.setContentType("application/json; charset=UTF-8");
                 response.getWriter().write(objectMapper.writeValueAsString(commonResponseDTO));
+                return;
             }
+        }else {
+            // 인증정보가 존재하지 않을때
+            CommonResponseDTO commonResponseDTO = new CommonResponseDTO("토큰이 유효하지 않습니다.", HttpStatus.FORBIDDEN.value());
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setContentType("application/json; charset=UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(commonResponseDTO));
+            return;
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/backoffice/global/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/backoffice/global/security/AuthenticationFilter.java
@@ -59,13 +59,6 @@ public class AuthenticationFilter extends OncePerRequestFilter {
                 response.getWriter().write(objectMapper.writeValueAsString(commonResponseDTO));
                 return;
             }
-        }else {
-            // 인증정보가 존재하지 않을때
-            CommonResponseDTO commonResponseDTO = new CommonResponseDTO("토큰이 유효하지 않습니다.", HttpStatus.FORBIDDEN.value());
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            response.setContentType("application/json; charset=UTF-8");
-            response.getWriter().write(objectMapper.writeValueAsString(commonResponseDTO));
-            return;
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/example/backoffice/global/security/JwtUtil.java
+++ b/src/main/java/com/example/backoffice/global/security/JwtUtil.java
@@ -74,11 +74,7 @@ public class JwtUtil {
 
     // 토큰에서 유저 정보를 뽑아오기. 유저정보는 claims에 들어있으므로 claim를 반환
     public Claims getUserInfoFromToken(String token) {
-        try {
             return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
-        } catch (NullPointerException e){
-            throw new NonUserExsistException(NON_USER_EXSIST);
-        }
     }
 
     // jwt 토큰을 만드는 메서드.

--- a/src/main/java/com/example/backoffice/global/security/JwtUtil.java
+++ b/src/main/java/com/example/backoffice/global/security/JwtUtil.java
@@ -27,9 +27,10 @@ public class JwtUtil {
 
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
+    public static final String REFRESH_PREFIX = "Refresh ";
 
-//    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
-    private String secretKey = "1a1b95adsfadf36d65432b16d4ded7f2814c8e5105ceae7ced4e173b086c564f2efa609d03c8ab84a78492f3175c0ce8ef792d6e55157f34777628f6f55163ef115bfe4";
+    @Value("${jwt.secret.key}") // Base64 Encode 한 SecretKey
+    private String secretKey;
 
     // secret key 암호화 알고리즘
     private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;

--- a/src/main/java/com/example/backoffice/global/security/JwtUtil.java
+++ b/src/main/java/com/example/backoffice/global/security/JwtUtil.java
@@ -1,5 +1,6 @@
 package com.example.backoffice.global.security;
 
+import com.example.backoffice.domain.user.exception.NonUserExsistException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -14,12 +15,15 @@ import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
 
+import static com.example.backoffice.domain.user.exception.UserErrorCode.NON_USER_EXSIST;
+
 @Slf4j
 @Component
 public class JwtUtil {
 
     // Header KEY 값
     public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_AUTHORIZATION_HEADER = "Refresh_Auth";
 
     // Token 식별자
     public static final String BEARER_PREFIX = "Bearer ";
@@ -70,7 +74,11 @@ public class JwtUtil {
 
     // 토큰에서 유저 정보를 뽑아오기. 유저정보는 claims에 들어있으므로 claim를 반환
     public Claims getUserInfoFromToken(String token) {
-        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (NullPointerException e){
+            throw new NonUserExsistException(NON_USER_EXSIST);
+        }
     }
 
     // jwt 토큰을 만드는 메서드.

--- a/src/main/java/com/example/backoffice/global/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/backoffice/global/security/WebSecurityConfig.java
@@ -55,7 +55,8 @@ public class WebSecurityConfig {
         http.authorizeHttpRequests((authorizeHttpRequests) ->
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-                        .requestMatchers("/api/users/**").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/api/users/signup").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허가
+                        .requestMatchers("/api/users/login").permitAll() // '/api/users/'로 시작하는 요청 모두 접근 허
                         .requestMatchers("/api/posts/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
         );


### PR DESCRIPTION
필터단 예외 발생 시 예외 응답
기존에는 필터단에서 예외 발생시 컨트롤러까지 예외가 넘어갔었습니다.
이제는 필터단에서 인증이 유효하지 않을 경우 필터단에서 예외가 터지고, 예외를 클라이언트에 응답합니다.

Post Service & Post Repository 오타 수정